### PR TITLE
update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: r
 cache: packages
+os: linux
+dist: xenial
 
 r:
-  - oldrel
+  - 3.5
+  - 3.6
   - release
   - devel
 
@@ -43,7 +46,7 @@ after_success:
 deploy:
   # our site to gh_pages
   - provider: pages
-    skip_cleanup: true
+    cleanup: false
     token: $GH_TOKEN
     keep_history: false
     local_dir: docs
@@ -53,7 +56,7 @@ deploy:
   # our image to dockerhub
   - provider: script
     script: bash docker_push
-    skip_cleanup: true
+    cleanup: false
     on:
       all_branches: true
       condition: $TRAVIS_R_VERSION_STRING == "release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ after_success:
 deploy:
   # our site to gh_pages
   - provider: pages
-    cleanup: false
+    skip_cleanup: true
     token: $GH_TOKEN
     keep_history: false
     local_dir: docs
@@ -56,7 +56,7 @@ deploy:
   # our image to dockerhub
   - provider: script
     script: bash docker_push
-    cleanup: false
+    skip_cleanup: true
     on:
       all_branches: true
       condition: $TRAVIS_R_VERSION_STRING == "release"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ environment:
 
 build_script:
   - travis-tool.sh install_deps
+  - travis-tool.sh install_github rstudio/htmltools
   - travis-tool.sh install_github rstudio/shiny
 
 test_script:


### PR DESCRIPTION
- run `R` versions `3.5`, `3.6`, `release` (`4.0` at the moment) and `devel`
- remove ~~all~~ warnings/notes from `travis lint .travis.yml`
  - Define `os` and `dist`.
  - ~~Use `cleanup: false` instead of `skip_cleanup: true`.~~ (EDIT: did not work)

With this PR we will still test `R` version 3, even if `release` is `4.1` (then `oldrel` would be `4.0`).