### PR TITLE
Only keep data with type == "andel" and context == "caregiver"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qmongr
 Title: Lightweight Quality Assessment of Norwegian Hospitals 
-Version: 1.2.0
+Version: 1.3.0
 Authors@R: c(
     person(given = "Yohannes",
            family = "Tesfay",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# qmongr 1.3.0
+
+Only keep data with `type == "andel"` and `context == "caregiver"` ([#218](https://github.com/mong/qmongr/pull/218)).
+
 # qmongr 1.2.0
 
 Using commit [80b3ec8](https://github.com/mong/qmongjs/commit/80b3ec8) of `qmongjs`

--- a/R/data_source.R
+++ b/R/data_source.R
@@ -30,8 +30,7 @@ get_data <- function() {
       dplyr::inner_join(registry, by = conf$column$registry_id)
     df <- imongr::get_table(pool, "agg_data")
 
-    # filter
-    # Keep include == 1 and type == "andel"
+    # filter (keep) include == 1 and type == "andel"
     # qmongjs is not able to show other types than "andel"
     include <- dplyr::select(description, .data$id, .data$include, .data$type)
     df <- df %>%

--- a/R/data_source.R
+++ b/R/data_source.R
@@ -31,12 +31,13 @@ get_data <- function() {
     df <- imongr::get_table(pool, "agg_data")
 
     # filter
-    ## include
-    include <- dplyr::select(description, .data$id, .data$include)
+    ## include == 1 and type not "dg"
+    include <- dplyr::select(description, .data$id, .data$include, .data$type)
     df <- df %>%
       dplyr::left_join(include, by = c("ind_id" = "id"))
     df <- df %>%
-      dplyr::filter(.data$include == 1)
+      dplyr::filter(.data$include == 1) %>%
+      dplyr::filter(.data$type != "dg") %>%
     ## coverage
     if (conf$filter$coverage$use) {
       df <- df %>%

--- a/R/data_source.R
+++ b/R/data_source.R
@@ -30,14 +30,16 @@ get_data <- function() {
       dplyr::inner_join(registry, by = conf$column$registry_id)
     df <- imongr::get_table(pool, "agg_data")
 
-    # filter (keep) include == 1 and type == "andel"
-    # qmongjs is not able to show other types than "andel"
     include <- dplyr::select(description, .data$id, .data$include, .data$type)
     df <- df %>%
       dplyr::left_join(include, by = c("ind_id" = "id"))
+    # Only keep include == 1, type == "andel" and context == "caregiver"
+    # qmongr is not able to show other types than "andel" or
+    # other context than "caregiver.
     df <- df %>%
       dplyr::filter(.data$include == 1) %>%
-      dplyr::filter(.data$type == "andel")
+      dplyr::filter(.data$type == "andel") %>%
+      dplyr::filter(.data$context == "caregiver")
     ## coverage
     if (conf$filter$coverage$use) {
       df <- df %>%

--- a/R/data_source.R
+++ b/R/data_source.R
@@ -31,13 +31,14 @@ get_data <- function() {
     df <- imongr::get_table(pool, "agg_data")
 
     # filter
-    ## include == 1 and type not "dg"
+    # Keep include == 1 and type == "andel"
+    # qmongjs is not able to show other types than "andel"
     include <- dplyr::select(description, .data$id, .data$include, .data$type)
     df <- df %>%
       dplyr::left_join(include, by = c("ind_id" = "id"))
     df <- df %>%
       dplyr::filter(.data$include == 1) %>%
-      dplyr::filter(.data$type != "dg")
+      dplyr::filter(.data$type == "andel")
     ## coverage
     if (conf$filter$coverage$use) {
       df <- df %>%

--- a/R/data_source.R
+++ b/R/data_source.R
@@ -37,7 +37,7 @@ get_data <- function() {
       dplyr::left_join(include, by = c("ind_id" = "id"))
     df <- df %>%
       dplyr::filter(.data$include == 1) %>%
-      dplyr::filter(.data$type != "dg") %>%
+      dplyr::filter(.data$type != "dg")
     ## coverage
     if (conf$filter$coverage$use) {
       df <- df %>%


### PR DESCRIPTION
This is so we can set these indicators to include = 1 but still not
show them in the app.

It is working locally.